### PR TITLE
Update, Custom Name nows supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,14 @@ Otherwise, follow these instructions
         "highFspeed": true,
         "topFspeed": false,
         "autoFspeed": true,
+        "customDeviceNames": {
+          "deviceID1": "Custom Name 1",
+          "deviceID2": "Custom Name 2"
+        },
         "debug": false
     }
 ]
+
 ```
 
 
@@ -96,6 +101,7 @@ Otherwise, follow these instructions
 | `highFspeed`                   |  Support "High" fan speed                                 |          |   true   |  Boolean |
 | `topFspeed`                    |  Support "Very-High/Top" fan speed                        |          |   true   |  Boolean |
 | `autoFspeed`                   |  Support "Auto" fan speed                                 |          |   true   |  Boolean |
+| `customDeviceNames`            |  instead of L5.008 AC, add in a friendly e.g Kitchen AC   |          |   -      |  Sring   |
 | `debug` |  When set to `true`, the plugin will produce extra logs for debugging purposes   |          |  `false` |  Boolean |
 
 ### Fan speeds & "AUTO" speed

--- a/config-sample.json
+++ b/config-sample.json
@@ -25,6 +25,10 @@
       "highFspeed": true,
       "topFspeed": false,
       "autoFspeed": true,
+      "customDeviceNames": {
+        "deviceID1": "Custom Name 1",
+        "deviceID2": "Custom Name 2"
+      },
       "debug": false
     }
   ],

--- a/config.schema.json
+++ b/config.schema.json
@@ -102,6 +102,17 @@
                 "default": true,
                 "required": true
             },
+            "customDeviceNames": {
+                "title": "Custom Device Names",
+                "description": "Map of device IDs to custom names",
+                "type": "object",
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
             "debug": {
                 "title": "Enable Debug Logs",
                 "description": "When checked, the plugin will produce extra logs for debugging purposes",
@@ -116,6 +127,9 @@
 			"key": "ip"
 		},
 		{
+            "key": "customDeviceNames"
+          },
+        {
 			"key": "debug"
 		},
 		{

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ class CoolAutomationPlatform {
 
 		this.cachedAccessories = []
 		this.activeAccessories = []
+		this.customDeviceNames = config['customDeviceNames'] || {}
 		this.log = log
 		this.api = api
 		this.storage = storage


### PR DESCRIPTION
Now you can use custom names for your coolplugs instead of the confusing technical names, change name from L5.008 to Kitchen AC